### PR TITLE
Matomo tracking replaces Google Analytics

### DIFF
--- a/src/web/components/PDFButton.js
+++ b/src/web/components/PDFButton.js
@@ -4,11 +4,13 @@ import PropTypes from 'prop-types';
 import Spinner from '../primitives/Spinner';
 import createPDF from '../utils/create-pdf';
 import { MainButton } from '../primitives/Button';
+import { trackEvent } from '../utils/tracking';
 
 export default class PDFButton extends Component {
   static propTypes = {
     pdfServiceUrl: PropTypes.string.isRequired,
     localStorageKey: PropTypes.string.isRequired,
+    pageHeading: PropTypes.string.isRequired,
   }
 
   state = {
@@ -17,7 +19,7 @@ export default class PDFButton extends Component {
   };
 
   handleClick = () => {
-    const { pdfServiceUrl, localStorageKey } = this.props;
+    const { pdfServiceUrl, localStorageKey, pageHeading } = this.props;
     const { isDownloading } = this.state;
 
     if (isDownloading) { return; }
@@ -26,6 +28,8 @@ export default class PDFButton extends Component {
       isDownloading: true,
       errorMessage: false,
     });
+
+    trackEvent('Last ned PDF', pageHeading);
 
     createPDF(pdfServiceUrl, localStorageKey)
       .then(() => {

--- a/src/web/components/Result.js
+++ b/src/web/components/Result.js
@@ -5,6 +5,7 @@ import React from 'react';
 import hasSoftError from '../utils/has-soft-error';
 import getResultText from '../utils/get-result-text';
 import { getErrorPages } from '../utils/selectors';
+import { trackEvent } from '../utils/tracking';
 import Block from './blocks/Block';
 import ExportData from './ExportData';
 import Html from './helper/Html';
@@ -46,6 +47,11 @@ function Result(props) {
   const resultHeading = getResultText(heading, incomplete, hasSoftErrors);
   const resultLead = getResultText(lead, incomplete, hasSoftErrors);
 
+  const printPage = () => {
+    trackEvent('Skriv ut', resultHeading);
+    window.print();
+  };
+
   return (
     <Main result debug={debug} data-id={pageid} id="main">
       <H1 result>{resultHeading}</H1>
@@ -84,10 +90,11 @@ function Result(props) {
             <PDFButton
               pdfServiceUrl={pdfServiceUrl}
               localStorageKey={localStorageKey}
+              pageHeading={resultHeading}
             />
           )
           : (
-            <MainButton type="button" onClick={() => window.print()}>
+            <MainButton type="button" onClick={printPage}>
               Skriv ut
             </MainButton>
           )}

--- a/src/web/utils/tracking.js
+++ b/src/web/utils/tracking.js
@@ -1,22 +1,16 @@
-/* eslint no-undef: 0 */
+/* eslint no-underscore-dangle: 0 */
 export default function track(wizardName, id, title) {
-  if (typeof window.dataLayer === 'undefined') {
-    window.dataLayer = [];
-  }
-  // DIBK tracking oppsett
-  window.dataLayer.push({
-    'newpage.path': `/verktoy-og-veivisere/${wizardName}/${id}`, // virtuell path til siden
-    'newpage.title': title, // Tittel for den virtuelle siden. Dette er i dag plasser som event navn.
-    event: 'newpage', // eventnavn som gjennbrukes for alle nye sider
-  });
+  const _paq = window._paq || [];
+
+  // DIBK tracking setup for Matomo
+  _paq.push(['setCustomUrl', `https://dibk.no/verktoy-og-veivisere/${wizardName}/${id}`]); // Virtual path
+  _paq.push(['setDocumentTitle', title]); // Title for virtual page
+  _paq.push(['trackPageView']);
 }
 
-export function trackEvent(name) {
-  if (typeof window.dataLayer === 'undefined') {
-    window.dataLayer = [];
-  }
-  // DIBK tracking oppsett
-  window.dataLayer.push({
-    event: name,
-  });
+export function trackEvent(action, name = '') {
+  const _paq = window._paq || [];
+
+  // DIBK tracking setup for Matomo
+  _paq.push(['trackEvent', 'Wizard', action, name]);
 }


### PR DESCRIPTION
Due to the [new verdict from Datatilsynet](https://www.datatilsynet.no/aktuelt/aktuelle-nyheter-2023/varsel-om-vedtak-i-google-analytics-saken/) where Google Analytics is considered to violate GDPR regulations we want to remove this tool from Losen. Dibk.no are transitioning to using [Matomo Analytics](https://matomo.org/) so the tracking method in Losen will now be replaced by a Matomo method. 

**NB**: This will be a breaking change for those that still use Google Analytics. The only consequence would be that the tracking is lost, but the wizard would still work. 

For those using Matomo all ready this would give you page views for each visited step in the wizard. You will get custom events under the category "Wizard".

We have also added tracking events on Print and Download buttons from the result pages. 