### PR TITLE
Accessibility improvements for new WCAG 2.1 requirements

### DIFF
--- a/.storybook/stories/building-blocks/common.js
+++ b/.storybook/stories/building-blocks/common.js
@@ -60,6 +60,14 @@ export const optional = (
   </tr>
 )
 
+export const autocoomplete = (
+  <tr key="autocomplete">
+    <td><code>autocomplete</code></td>
+    <td>The autocomplete content attribute can be used to hint to the browser how to, or whether to, help the user fill forms in. For example prefilling the user's name, address or phone numbers based on earlier input. This is an accessibility requirement if there are relevant codes available. See UUtilsynet for <a href="https://www.uutilsynet.no/veiledning/135-identifiser-formal-med-inndata/1238">documentation on available codes</a>. This field is optional.</td>
+    <td></td>
+  </tr>
+)
+
 export const inputProperties = [
   property,
   heading,

--- a/.storybook/stories/building-blocks/input.js
+++ b/.storybook/stories/building-blocks/input.js
@@ -47,6 +47,7 @@ export default function SchemaBuildingBlocks() {
             </td>
             <td></td>
           </tr>
+          {common.autocoomplete}
           {common.optional}
           {common.show}
           {common.hide}
@@ -59,6 +60,7 @@ export default function SchemaBuildingBlocks() {
   "id": "favourite.actor",
   "property": "favourite.actor",
   "type": "Input",
+  "autocomplete": "name",
   "validator": {
     "pattern": "^\\d+(,\\d+)?$",
     "error": "Oppgi på formatet 123,1239"

--- a/.storybook/stories/building-blocks/select.js
+++ b/.storybook/stories/building-blocks/select.js
@@ -48,6 +48,7 @@ export default function SchemaBuildingBlocks() {
             <td>The text to follow the heading for this input field.</td>
             <td></td>
           </tr>
+          {common.autocoomplete}
           {common.optionalInputProperties}
         </tbody>
       </Table>

--- a/.storybook/stories/building-blocks/textarea.js
+++ b/.storybook/stories/building-blocks/textarea.js
@@ -52,6 +52,7 @@ export default function SchemaBuildingBlocks() {
             </td>
             <td></td>
           </tr>
+          {common.autocoomplete}
           {common.optional}
           {common.show}
           {common.hide}

--- a/.storybook/stories/primitives/blocks.js
+++ b/.storybook/stories/primitives/blocks.js
@@ -42,7 +42,7 @@ export default function PrimitivesIntro() {
 
     <H2>Error block</H2>
     <p>An error block is basically a grouped block with custom styling.</p>
-    <StyledErrorBlock>
+    <StyledErrorBlock role="alert">
       <SpecificBlock groupedSimple>
         <H2>This is an error block</H2>
       </SpecificBlock>

--- a/.storybook/stories/primitives/errors.js
+++ b/.storybook/stories/primitives/errors.js
@@ -10,7 +10,7 @@ export default function PrimitivesIntro() {
     <H1>Errors and warnings</H1>
     <H2>Validation error</H2>
     <div>
-        <ErrorMessage>
+        <ErrorMessage role="alert">
             <svg
               xmlns="http://www.w3.org/2000/svg"
               viewBox="0 0 38 38"
@@ -51,7 +51,7 @@ export default function PrimitivesIntro() {
     <hr />
 
     <H2>Error block</H2>
-    <StyledErrorBlock>
+    <StyledErrorBlock role="alert">
       <SpecificBlock groupedSimple>
         <H2>This is an error block</H2>
       </SpecificBlock>

--- a/.storybook/stories/primitives/loading.js
+++ b/.storybook/stories/primitives/loading.js
@@ -5,7 +5,7 @@ import Loading from '../../../src/web/primitives/Loading';
 export default function PrimitivesIntro() {
   return (<div>
     <H1>Loading</H1>
-    <Loading>
+    <Loading role="status">
       Loading something
     </Loading>
   </div>);

--- a/src/web/components/ExportData.js
+++ b/src/web/components/ExportData.js
@@ -64,7 +64,7 @@ class ExportData extends Component {
     this.setState({ copied: true });
     setTimeout(() => {
       this.setState({ copied: false });
-    }, 2000);
+    }, 5000);
   };
 
   render() {
@@ -72,7 +72,7 @@ class ExportData extends Component {
 
     return (
       <div>
-        <MainButton copied={this.state.copied} onClick={this.copyToClipboard}>
+        <MainButton aria-live={this.state.copied ? 'assertive' : undefined} copied={this.state.copied} onClick={this.copyToClipboard}>
           {buttonText}
         </MainButton>
       </div>

--- a/src/web/components/NavItem.js
+++ b/src/web/components/NavItem.js
@@ -8,11 +8,11 @@ export default function NavItem({ active, done, heading, id, index, setPage }) {
     <StyledNavItem
       active={active}
       done={done}
+      href="#"
       onClick={(e) => {
         e.preventDefault();
         setPage(id);
       }}
-      tabIndex={0}
     >
       <div>{index}</div>
       <p>

--- a/src/web/components/Summary/Node.js
+++ b/src/web/components/Summary/Node.js
@@ -44,13 +44,13 @@ export default function NodeSummary({ node }) {
       <Html text={heading} h3 />
       <ValueSummary value={currentValue} node={node} />
       {errors.validation.error ? (
-        <ErrorMessage>
+        <ErrorMessage role="alert">
           <ErrorIcon />
           {errors.validation.message}
         </ErrorMessage>
       ) : null}
       {errors.disabled.length ? (
-        <ErrorMessage>
+        <ErrorMessage role="alert">
           <ErrorIcon /> {errorDescription}
         </ErrorMessage>
       ) : null}

--- a/src/web/components/Summary/SoftError.js
+++ b/src/web/components/Summary/SoftError.js
@@ -13,7 +13,7 @@ export default function SoftError({ children }) {
         const heading = child.heading || child.text;
         if (heading) {
           return (
-            <ErrorMessage>
+            <ErrorMessage role="alert">
               <ErrorIcon /> <Html text={heading} inline />
             </ErrorMessage>
           );

--- a/src/web/components/Wizard.js
+++ b/src/web/components/Wizard.js
@@ -21,6 +21,7 @@ import beforeUnloadHandler from '../utils/before-unload-handler';
 import validateSchema from '../../shared/utils/validator';
 
 import Grid from '../primitives/grid/Grid';
+import FocusWrapper from '../primitives/grid/FocusWrapper';
 import StyledWizard from '../primitives/Wizard';
 
 class Wizard extends Component {
@@ -75,6 +76,8 @@ class Wizard extends Component {
       showResetModal: props.showResetModal && !!Object.keys(wizardData).length,
     };
 
+    this.pageWrapper = null;
+
     if (wizardData.page) {
       this.setPage(wizardData.page);
     }
@@ -94,6 +97,7 @@ class Wizard extends Component {
   componentDidUpdate = (prevProps, prevState) => {
     if (this.state.page !== prevState.page) {
       this.trackPage();
+      if (this.pageWrapper) this.pageWrapper.focus(); // Move keyboard focus to wrapper
     }
   }
 
@@ -121,7 +125,6 @@ class Wizard extends Component {
     }
     this.props.setData('page', page);
     this.setState({ page });
-    document.activeElement.blur(); // Remove focus on next/prev buttons after page change
   }
 
   getCurrentIndex = () => Math.max(
@@ -229,30 +232,32 @@ ${error}
               showIntro={showIntro}
               translations={translations}
             />
-            {page && page.type === 'Result' ? (
-              <Result
-                {...page}
-                previousPage={this.previousPage}
-                debug={debug}
-                pageid={page.id}
-                wizard={wizard}
-                title={title}
-                schema={schema}
-                setPage={this.setPage}
-                exports={exports}
-              />
-            ) : (
-              page && <Page
-                firstPage={firstPage}
-                lastPage={lastPage}
-                nextPage={this.nextPage}
-                previousPage={this.previousPage}
-                debug={debug}
-                nextPageIsResult={nextPageIsResult}
-                pageid={page.id}
-                {...page}
-              />
-            )}
+            <FocusWrapper tabIndex="-1" innerRef={e => (this.pageWrapper = e)}>
+              {page && page.type === 'Result' ? (
+                <Result
+                  {...page}
+                  previousPage={this.previousPage}
+                  debug={debug}
+                  pageid={page.id}
+                  wizard={wizard}
+                  title={title}
+                  schema={schema}
+                  setPage={this.setPage}
+                  exports={exports}
+                />
+              ) : (
+                page && <Page
+                  firstPage={firstPage}
+                  lastPage={lastPage}
+                  nextPage={this.nextPage}
+                  previousPage={this.previousPage}
+                  debug={debug}
+                  nextPageIsResult={nextPageIsResult}
+                  pageid={page.id}
+                  {...page}
+                />
+              )}
+            </FocusWrapper>
           </Grid>
         </StyledWizard>
       </StyleProvider>

--- a/src/web/components/blocks/Block.js
+++ b/src/web/components/blocks/Block.js
@@ -148,7 +148,7 @@ export function PureBlock(props) {
 
   if (props.type === 'Error') {
     return (
-      <StyledErrorBlock data-id={props.id} debug={props.debug}>
+      <StyledErrorBlock role="alert" data-id={props.id} debug={props.debug}>
         <Html text={props.heading} h2 />
         <Html text={props.text} />
 

--- a/src/web/components/blocks/Block.js
+++ b/src/web/components/blocks/Block.js
@@ -223,7 +223,7 @@ export function PureBlock(props) {
         />
 
         {props.disabled && (
-          <ErrorMessage>
+          <ErrorMessage role="alert">
             <ErrorIcon /> {props.errorDescription}
           </ErrorMessage>
         )}

--- a/src/web/components/blocks/FetchOrg.js
+++ b/src/web/components/blocks/FetchOrg.js
@@ -170,7 +170,7 @@ export default class FetchOrg extends Component {
         {get(this.props, 'currentValue.dataOrg', false) && (
           <div>
             <br />
-            <DL>
+            <DL role="status">
               <dt>Firmaets navn</dt>
               <dd>{get(this.props, 'currentValue.name')}</dd>
 
@@ -192,7 +192,7 @@ export default class FetchOrg extends Component {
         <div>
           {get(this.props, 'currentValue.fetchSG', false)}
           <div>
-            {loading && <Loading>Laster inn data</Loading>}
+            {loading && <Loading role="status">Laster inn data</Loading>}
             {!loading &&
               get(this.props, 'currentValue.dataSG', false) &&
               (

--- a/src/web/components/blocks/FetchOrg.js
+++ b/src/web/components/blocks/FetchOrg.js
@@ -212,7 +212,7 @@ export default class FetchOrg extends Component {
         </div>
         <div>
           {get(this.props, 'currentValue.invalidOrg', false) && (
-            <ErrorMessage>
+            <ErrorMessage role="alert">
               <ErrorIcon /> {invalidOrg}
             </ErrorMessage>
           )}

--- a/src/web/components/blocks/Input.js
+++ b/src/web/components/blocks/Input.js
@@ -21,6 +21,7 @@ export default class Input extends Component {
     max: PropTypes.number,
     min: PropTypes.number,
     placeholder: PropTypes.string,
+    autocomplete: PropTypes.string,
     property: PropTypes.string.isRequired,
     setData: PropTypes.func.isRequired,
     step: PropTypes.number,
@@ -42,6 +43,7 @@ export default class Input extends Component {
     update: () => {},
     validation: {},
     toggle: [],
+    autocomplete: undefined,
   };
 
   updateToggle = (value) => {
@@ -88,6 +90,7 @@ export default class Input extends Component {
       heading,
       max,
       min,
+      autocomplete,
       placeholder,
       property,
       step,
@@ -112,6 +115,7 @@ export default class Input extends Component {
         id={property}
         onChange={this.handleChange}
         placeholder={placeholder}
+        autoComplete={autocomplete}
         type={inputType}
         validation={errors.validation}
         value={currentValue}
@@ -128,6 +132,7 @@ export default class Input extends Component {
           max={max}
           min={min}
           onChange={this.handleChange}
+          autoComplete={autocomplete}
           placeholder={placeholder}
           step={step}
           type={inputType}

--- a/src/web/components/blocks/Input.js
+++ b/src/web/components/blocks/Input.js
@@ -102,6 +102,7 @@ export default class Input extends Component {
       <TextInput
         aria-label={heading}
         aria-invalid={errors.validation.error}
+        aria-describedby={errors.validation.error ? `${property}.error` : undefined}
         disabled={disabled}
         id={property}
         onChange={this.handleChange}
@@ -116,6 +117,7 @@ export default class Input extends Component {
         <NumberInput
           aria-label={heading}
           aria-invalid={errors.validation.error}
+          aria-describedby={errors.validation.error ? `${property}.error` : undefined}
           disabled={disabled}
           id={property}
           max={max}
@@ -137,7 +139,7 @@ export default class Input extends Component {
         {unit ? <Html inline text={unit} /> : null}
 
         {errors.validation.error && (
-          <ErrorMessage>
+          <ErrorMessage role="alert" id={`${property}.error`}>
             <ErrorIcon /> {errors.validation.message}
           </ErrorMessage>
         )}

--- a/src/web/components/blocks/Input.js
+++ b/src/web/components/blocks/Input.js
@@ -98,11 +98,16 @@ export default class Input extends Component {
     if (inputType === 'Input') {
       inputType = 'text';
     }
+
+    const describedBy = [];
+    if (unit) describedBy.push(`${property}.unit`);
+    if (errors.validation.error) describedBy.push(`${property}.error`);
+
     let input = (
       <TextInput
         aria-label={heading}
         aria-invalid={errors.validation.error}
-        aria-describedby={errors.validation.error ? `${property}.error` : undefined}
+        aria-describedby={describedBy.length > 0 ? describedBy.join(' ') : undefined}
         disabled={disabled}
         id={property}
         onChange={this.handleChange}
@@ -117,7 +122,7 @@ export default class Input extends Component {
         <NumberInput
           aria-label={heading}
           aria-invalid={errors.validation.error}
-          aria-describedby={errors.validation.error ? `${property}.error` : undefined}
+          aria-describedby={describedBy.length > 0 ? describedBy.join(' ') : undefined}
           disabled={disabled}
           id={property}
           max={max}
@@ -136,7 +141,7 @@ export default class Input extends Component {
       <div>
         {input}
 
-        {unit ? <Html inline text={unit} /> : null}
+        {unit ? <Html inline id={`${property}.unit`} text={unit} /> : null}
 
         {errors.validation.error && (
           <ErrorMessage role="alert" id={`${property}.error`}>

--- a/src/web/components/blocks/Input.js
+++ b/src/web/components/blocks/Input.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
 import { ErrorMessage } from '../../primitives/Errors';
-import { SRLabel } from '../../primitives/Label';
 import { TextInput, NumberInput } from '../../primitives/Input';
 import ErrorIcon from '../graphics/ErrorIcon';
 import Html from '../helper/Html';
@@ -99,14 +98,10 @@ export default class Input extends Component {
     if (inputType === 'Input') {
       inputType = 'text';
     }
-    let label = '';
-    if (heading) {
-      label = <SRLabel htmlFor={property}>{heading}</SRLabel>;
-    }
     let input = (
       <TextInput
-        aria-invalid={errors.validation.error}
         aria-label={heading}
+        aria-invalid={errors.validation.error}
         disabled={disabled}
         id={property}
         onChange={this.handleChange}
@@ -119,8 +114,8 @@ export default class Input extends Component {
     if (this.props.type === 'number') {
       input = (
         <NumberInput
-          aria-invalid={errors.validation.error}
           aria-label={heading}
+          aria-invalid={errors.validation.error}
           disabled={disabled}
           id={property}
           max={max}
@@ -137,7 +132,6 @@ export default class Input extends Component {
     }
     return (
       <div>
-        {label}
         {input}
 
         {unit ? <Html inline text={unit} /> : null}

--- a/src/web/components/blocks/Textarea.js
+++ b/src/web/components/blocks/Textarea.js
@@ -11,6 +11,7 @@ export default class Textarea extends Component {
   static propTypes = {
     currentValue: PropTypes.string,
     information: PropTypes.string,
+    heading: PropTypes.string,
     placeholder: PropTypes.string,
     property: PropTypes.string.isRequired,
     setData: PropTypes.func,
@@ -19,6 +20,7 @@ export default class Textarea extends Component {
   static defaultProps = {
     currentValue: '',
     information: '',
+    heading: '',
     placeholder: '',
     setData: () => {},
   };
@@ -31,11 +33,12 @@ export default class Textarea extends Component {
   };
 
   render() {
-    const { currentValue, information, placeholder } = this.props;
+    const { currentValue, information, heading, placeholder } = this.props;
 
     return (
       <div>
         <StyledTextarea
+          aria-label={heading}
           placeholder={placeholder}
           value={currentValue}
           onChange={this.handleChange}

--- a/src/web/components/blocks/Textarea.js
+++ b/src/web/components/blocks/Textarea.js
@@ -33,18 +33,19 @@ export default class Textarea extends Component {
   };
 
   render() {
-    const { currentValue, information, heading, placeholder } = this.props;
+    const { currentValue, information, heading, placeholder, property } = this.props;
 
     return (
       <div>
         <StyledTextarea
           aria-label={heading}
+          aria-describedby={information ? `${property}.information` : undefined}
           placeholder={placeholder}
           value={currentValue}
           onChange={this.handleChange}
         />
         {information && (
-          <Information>
+          <Information id={`${property}.information`}>
             <ErrorIcon triangleFill={'black'} />
             <Html text={information} />
           </Information>

--- a/src/web/components/blocks/Textarea.js
+++ b/src/web/components/blocks/Textarea.js
@@ -13,6 +13,7 @@ export default class Textarea extends Component {
     information: PropTypes.string,
     heading: PropTypes.string,
     placeholder: PropTypes.string,
+    autocomplete: PropTypes.string,
     property: PropTypes.string.isRequired,
     setData: PropTypes.func,
   };
@@ -23,6 +24,7 @@ export default class Textarea extends Component {
     heading: '',
     placeholder: '',
     setData: () => {},
+    autocomplete: undefined,
   };
 
   handleChange = (e) => {
@@ -33,7 +35,7 @@ export default class Textarea extends Component {
   };
 
   render() {
-    const { currentValue, information, heading, placeholder, property } = this.props;
+    const { currentValue, information, heading, placeholder, property, autocomplete } = this.props;
 
     return (
       <div>
@@ -43,6 +45,7 @@ export default class Textarea extends Component {
           placeholder={placeholder}
           value={currentValue}
           onChange={this.handleChange}
+          autoComplete={autocomplete}
         />
         {information && (
           <Information id={`${property}.information`}>

--- a/src/web/components/blocks/select/Select.js
+++ b/src/web/components/blocks/select/Select.js
@@ -11,6 +11,7 @@ export default class Select extends Component {
     currentValue: PropTypes.any,
     debug: PropTypes.bool,
     defaultOption: PropTypes.string,
+    heading: PropTypes.string,
     options: PropTypes.array.isRequired,
     property: PropTypes.string.isRequired,
     setData: PropTypes.func.isRequired,
@@ -44,12 +45,12 @@ export default class Select extends Component {
   };
 
   render() {
-    const { currentValue, options, defaultOption, debug } = this.props;
-    const heading = defaultOption || 'Velg fra listen';
+    const { currentValue, options, defaultOption, heading, debug } = this.props;
+    const placeholder = defaultOption || 'Velg fra listen';
     return (
       <SelectWrapper>
-        <select value={currentValue} onChange={this.handleChange}>
-          <option value={NULL_VALUE}>{heading}</option>
+        <select aria-label={heading} value={currentValue} onChange={this.handleChange}>
+          <option value={NULL_VALUE}>{placeholder}</option>
 
           {options.map(option => (
             <SelectOption debug={debug} {...option} key={option.value} />

--- a/src/web/components/blocks/select/Select.js
+++ b/src/web/components/blocks/select/Select.js
@@ -15,6 +15,7 @@ export default class Select extends Component {
     options: PropTypes.array.isRequired,
     property: PropTypes.string.isRequired,
     setData: PropTypes.func.isRequired,
+    autocomplete: PropTypes.string,
   }
 
   static defaultProps = {
@@ -23,6 +24,7 @@ export default class Select extends Component {
     defaultOption: '',
     heading: '',
     text: '',
+    autocomplete: undefined,
   }
 
   handleChange = (e) => {
@@ -45,11 +47,16 @@ export default class Select extends Component {
   };
 
   render() {
-    const { currentValue, options, defaultOption, heading, debug } = this.props;
+    const { currentValue, options, defaultOption, heading, autocomplete, debug } = this.props;
     const placeholder = defaultOption || 'Velg fra listen';
     return (
       <SelectWrapper>
-        <select aria-label={heading} value={currentValue} onChange={this.handleChange}>
+        <select
+          aria-label={heading}
+          value={currentValue}
+          onChange={this.handleChange}
+          autoComplete={autocomplete}
+        >
           <option value={NULL_VALUE}>{placeholder}</option>
 
           {options.map(option => (

--- a/src/web/components/helper/Modal.js
+++ b/src/web/components/helper/Modal.js
@@ -10,29 +10,33 @@ import { resetData } from '../../state/actions';
 import { H1 } from '../../primitives/Heading';
 import { Lead } from '../../primitives/Paragraphs';
 import { MainButton, SecondaryButton } from '../../primitives/Button';
+import ModalBox from '../../primitives/ModalBox';
 
 const customStyle = {
   overlay: {
     position: 'fixed',
+    zIndex: '1002',
     top: 0,
     left: 0,
     right: 0,
     bottom: 0,
     backgroundColor: 'rgba(0, 0, 0, 0.4)',
     display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'center',
+    flexDirection: 'column',
+    overflowY: 'scroll',
   },
   content: {
     position: 'static',
-    maxWidth: '666px',
-    margin: '0 auto',
-    border: '1px solid #ccc',
-    background: '#fff',
-    borderRadius: '0',
+    inset: '0',
+    overflow: 'visible',
+    background: 'transparent',
+    padding: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+    flexGrow: 1,
     outline: 'none',
-    padding: '40px 60px',
-    textAlign: 'center',
   },
 };
 
@@ -68,15 +72,17 @@ class Modal extends Component {
         onRequestClose={this.handleCloseModal}
         style={customStyle}
       >
-        <H1 id="heading">Vil du starte på nytt?</H1>
-        <Lead id="full_description">
-          Veiviseren husker svarene fra ditt forrige besøk.
-        </Lead>
-        <MainButton type="button" onClick={this.handleCloseModal}>Fortsett</MainButton>
-        <br />
-        <SecondaryButton type="button" onClick={this.handleRestart}>
-          Start på nytt
-        </SecondaryButton>
+        <ModalBox>
+          <H1 id="heading">Vil du starte på nytt?</H1>
+          <Lead id="full_description">
+            Veiviseren husker svarene fra ditt forrige besøk.
+          </Lead>
+          <MainButton type="button" onClick={this.handleCloseModal}>Fortsett</MainButton>
+          <br />
+          <SecondaryButton type="button" onClick={this.handleRestart}>
+            Start på nytt
+          </SecondaryButton>
+        </ModalBox>
       </ReactModal>
     );
   }

--- a/src/web/primitives/ModalBox.js
+++ b/src/web/primitives/ModalBox.js
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+
+import injectStyles from '../utils/inject-styles';
+
+const ModalBox = injectStyles(styled.div`
+  display: block;
+  max-width: 666px;
+  border: 1px solid #ccc;
+  background: #fff;
+  border-radius: 0;
+  padding: 40px 60px;
+  text-align: center;
+`);
+
+export default ModalBox;

--- a/src/web/primitives/grid/FocusWrapper.js
+++ b/src/web/primitives/grid/FocusWrapper.js
@@ -1,0 +1,12 @@
+import styled from 'styled-components';
+
+import injectStyles from '../../utils/inject-styles';
+
+const FocusWrapper = injectStyles(styled.div`
+  display: block;
+  &:focus {
+    outline: none;
+  }
+`);
+
+export default FocusWrapper;

--- a/src/web/styles.js
+++ b/src/web/styles.js
@@ -15,11 +15,11 @@ export default {
     bluegreen: '#54acb8',
     warmgray3: '#f2f1f0',
     warmgray2: '#e5e3e1',
-    darkgray: '#afaba8',
+    darkgray: '#989390',
     red: '#c1272d',
     lightred: '#ffeaeb',
     oldred: '#9d312f',
-    green: '#008B21',
+    green: '#007a1d',
     oldgreen: '#809e3d',
   },
   padding: {


### PR DESCRIPTION
Due to the [new Web Accessibility Directive (WAD) from EU](https://www.uutilsynet.no/webdirektivet-wad/eus-webdirektiv-wad/265) we have gotten new regulations for public sector websites in Norway. This introduce 12 new requirements from WCAG 2.1. This PR is a result of an expert review done by Joakim Bording from [Behalf](https://behalf.no/) where these requirements where tested for. 

# Issues
The review resulted in the following issues (in Norwegian). See [full testplan and issue list](https://docs.google.com/spreadsheets/d/1DKc2VuS_hXmqhDWeUTB0sfMeCxs_krkaQ02d4cEuQ8Y/edit?usp=sharing) in Google Docs.

Modul/Item | Topic | Severity (A/B/C) | Description | Resolved
-- | -- | -- | -- | --
Page head | 1.3.1 Informasjon og relasjoner | B | En skjult "Navigasjon" tittel i headeren burde fjernes. Den ødelegger hierarkiet i overskriftsnivåer og den trengs ikke da man allerede tar i bruk semantiske koder som kommuniserer det samme til de som bruker skjermlesere. To give your document a proper structure for assistive technologies, it is important to lay out your headings beginning with an h1. We found an h2 instead. Relevant code:`<h2 class="visually-hidden">Navigasjon</h2>` | Informert webredaktør på dibk.no
Page head | 1.1.1 Ikke tekstlig innhold | C | Tekstalternativ på Dibk logo i header er i dag "DiBk_logo_rgb". Som nok er filnavnet. Dette burde vært "Direktoratet for byggkvalitet". | Informert webredaktør på dibk.no
Venstre sidenavigasjon | Tastaturnavigasjon | A | Ikke mulig å klikke på et steg å navigere til det steget ved hjelp av tastaturet. Trolig er navigasjon kun knyttet til museklikk og ikke tastatur. Forventer å kunne navigere til riktig steg på samme vis som mus ved å trykke enter. | OK
Fortsett modal | 1.4.10 Dynamisk tilpasning (Reflow) | A | Ved 400% zoom kan man ikke scrolle i "Vil du fortsette" modalen og får dermed ikke tilgang til alt av innhold og funksjonalitet. Logo ligger dessuten over Modal. | OK
Skjema | 1.4.10 Dynamisk tilpasning (Reflow) | C | På 400% zoom blir tekstkolonnen veldig smal. Vi kunne med fordel fjernet mye horisontal padding for små skjermer. |  
Skjema | Kontaktperson navn | C | Tekstfelter har både h2, label og aria-label som viser det samme. Unødvendig. | OK
Skjema | 1.3.5 Identifisere formål med inndata | A | Tekstfelt bør kodes med en autocomplete verdi som korresponderer med typen innhold. I Erklæring om ansvarsrett har f.eks "Navn på kontaktperson" ikke autocomplete="name". | OK I losen, må oppdateres i veivisere også.
Skjemafelt | Ledetekster | C | I noen tilfeller blir det lang avstand mellom synlig ledetekst og felt. Se side 2 på Veiviser ansvar. |  
Select meny | Ledetekster | A | Alle nedtrekksmenyer mangler ledetekster. | OK
Textarea | Ledetekster | A | Alle textarea mangler ledetekster. | OK
Status message | 4.1.3 Statusbeskjeder | B | Statusmeldinger, feilmelding og lasting er ikke kodet med role="alert" eller role="status". | OK
Tekstfelt | 4.1.3 Statusbeskjeder | A | Feilmeldinger under tekstfelt er ikke riktig kodet til feltet og blir dermed ikke lest opp. Burde fått role="alert" og en aria-described-by kobling til input feltet. | OK
Kopier svarene til et fagsystem | 4.1.3 Statusbeskjeder | A | Trykker man "Kopier svarene til et fagsystem" endres knappeteksten kort som bekreftelse. Denne burde vart lengre og hatt korrekt kode role="alert" | OK
Buttons | 1.4.11 Kontrast for ikke-tekstlig innhold | C | Secondary button kan med fordel ha en outline med høyere kontrast. | OK
Radio | 1.4.11 Kontrast for ikke-tekstlig innhold | A | Radio inputs har en grå outline som ikke dekker kontrastkravet på 3:1 | OK
Checkbox | 1.4.11 Kontrast for ikke-tekstlig innhold | A | Checkbox inputs har en grå outline som ikke dekker kontrastkravet på 3:1 | OK
Input | 1.4.11 Kontrast for ikke-tekstlig innhold | A | Text input har en grå outline som ikke dekker kontrastkravet på 3:1 | OK
Select | 1.4.11 Kontrast for ikke-tekstlig innhold | A | Select har en grå outline som ikke dekker kontrastkravet på 3:1 | OK
Textarea | 1.4.11 Kontrast for ikke-tekstlig innhold | A | Textarea har en grå outline som ikke dekker kontrastkravet på 3:1 | OK
Tekstfelt | Ledetekster | B | Suffix til tekstfelt (m2) mer ikke koblet til input feltet med aria-described by. | OK
Page head | Fokus | C | Tastaturfokus flyttes ikke til toppen av siden ved navigasjon mellom sidene | OK

# Results
Losen should now comply with the required WCAG 2.1 level for public sector websites in Norway. 

## ❗️ Wizards should be updated
Wizards that use Losen now has the option of adding an `autocomplete` property to input, textarea and select fields. To comply with the new WCAG 2.1 requirements the schema of your wizard should be updated to use this property for those fields where that might be relevant. See the [Storybook documentation](https://dibk-storybook.firebaseapp.com/?selectedKind=The%20building%20blocks&selectedStory=Input&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel) for more information. 

## All changes
The following changes where done:

### a26e5067 Move keyboard focus on page change
When navigating between pages in the wizard keyboard focus was lost which is bad for those navigating by keyboard. The keyboard focus is now moved to a page wrapper after each navigation. 

### 0228a3cd Autocomplete property in schema for input, select and textarea
Input, Select and Textarea components now has the possibility of accepting an `autocomplete` property. This is used to tag fields semantically so that browsers can prefill it with stored information. 

### 0085f0ad Improved color contrast for input components and soft warnings
The border of input, radio, checkbox and select have got increased contrast of 3:1. Messages with green text have got increased contrast to 4.5:1.  

### 580ad64f Refactoring modal to add correct overflow scroll behaviour on small screens
Now it is possible to scroll in the modal on small screens. 

### b1242bf8 Bind unit to input field accessibly
Units is now read aloud when a screen reader has focus in an input field. 

### 929487fa Button copy behaviour with more accessible success message
When copying results the success message is now more accessible. 

### 6bdb4148 Get screenreaders to read out asynchron loaded content
Company information that is loaded asynchron is now read aloud to screen readers. 

### 93cd03e1 Get screenreaders to read error blocks out aloud
Error blocks are now read aloud to screen readers. 

### 58909de4 Bind inline error messages to input fields and trigger screenreaders to read them aloud
Inline error messages are now read aloud to screen readers. 

### d08b0b18 Removed duplicate label on inputs that is unnecessary
Cleanup of unused labels. 

### 83d46d46 Temporary fix for nav menu keyboard accessibility.
Navigation menu is now accessible for keyboard users. The fix is not ideal semantically (`<a href="#">`), but will be improved as part of the visual redesign that is planned. 

### fd468d9a Added missing aria-label to select and textarea
Select and Textarea components now have a label associated to them. 
