### PR TITLE
Implement variable substitution instead of depending on lodash.template

### DIFF
--- a/packages/losen/components/helper/VariableText.tsx
+++ b/packages/losen/components/helper/VariableText.tsx
@@ -1,15 +1,30 @@
 import React from 'react';
-import { template } from 'lodash';
 
 type Props = {
   text?: string
   data?: object
 }
 
+/**
+ * Takes a string and returns a function that takes an object with properties
+ * that should replace the variables in the string. The variables should be
+ * wrapped in ${}.
+ *
+ * Example: Hello ${name}, how are you this fine ${day}? would be turned into
+ * a function that takes an object like { name: 'John', day: 'morning' } and
+ * returns "Hello John, how are you this fine morning?"
+ */
+export function template(text: string) {
+  return function (variables: Record<string, any>) {
+    return text.replace(/\$\{([^}]+)\}/g, (match, name) => variables[name] || match);
+  };
+}
+
 export default function VariableText({ data = {}, text = "" }: Props) {
   if (!text) {
     return null;
   }
+
   const compiled = template(text);
 
   // eslint-disable-next-line react/no-danger

--- a/packages/losen/components/helper/test/VariableText.test.ts
+++ b/packages/losen/components/helper/test/VariableText.test.ts
@@ -1,0 +1,25 @@
+import { template } from "../VariableText"
+
+describe('VariableText', () => {
+  describe('template', () => {
+    it('should make a template from a string', () => {
+      const compile = template('Hei!')
+      expect(compile({})).toEqual('Hei!')
+    })
+
+    it('should replace a variable', () => {
+      const compile = template('Hei, ${name}!')
+      expect(compile({ name: 'Kristoffer' })).toEqual('Hei, Kristoffer!')
+    })
+
+    it('should replace multiple variables', () => {
+      const compile = template('Hei, ${name}! For en fin ${day}!')
+      expect(compile({ name: 'Kristoffer', day: 'morgen' })).toEqual('Hei, Kristoffer! For en fin morgen!')
+    })
+
+    it('should replace variables multiple times', () => {
+      const compile = template('${name}, ${name}, ${name}!')
+      expect(compile({ name: 'Kristoffer' })).toEqual('Kristoffer, Kristoffer, Kristoffer!')
+    })
+  })
+})


### PR DESCRIPTION
The lodash version uses eval under the hood, which is a problem on sites with content security policies that does not allow unsafe-eval. We don't want our users to be forced to enable it (for security reasons), so this is a better approach.