### PR TITLE
Updated PPMori font reference to match new dibk.no fontface implementation

### DIFF
--- a/packages/losen/styles.ts
+++ b/packages/losen/styles.ts
@@ -1,7 +1,7 @@
 const styles = {
   font: {
-    headline: '"PP Mori", "Open Sans", arial, helvetika, sans-serif',
-    body: '"PP Mori", "Altis-Light", "Altis", "Open Sans", arial, sans-serif',
+    headline: '"PPMori", "Open Sans", arial, helvetika, sans-serif',
+    body: '"PPMori", "Altis-Light", "Altis", "Open Sans", arial, sans-serif',
   },
   color2: {
     pageBackground: "#ebf4fa", // Havblå 50


### PR DESCRIPTION
After the redesign of dibk.no the new fontface implementation of PP Mori has changed it's name from "PP Mori" to "PPMori". This cause all wizards to now get the fallback font "Open sans" or similar. This PR updated the Losen packages. Remember to bump the version and publish it. 

Bear in mind that some of the old wizard implementations also override the font for some elements (like the left menu), and those repos should be udpates as well to completely fix this issue.

<img width="1597" height="1378" alt="image" src="https://github.com/user-attachments/assets/f7a975e6-ce12-47c4-854d-5f6b636dccb2" />
